### PR TITLE
Do not meddle in other packages' defaults

### DIFF
--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -50,9 +50,7 @@
 
 (defvar sd/old-ido-decorations)
 (defvar sd/old-ido-completions)
-(defvar sd/old-ido-enable-flex-matching)
-(defvar sd/old-ido-auto-merge-delay-time)
-(defvar sd/old-ido-ubiquitous-enable-compatibility)
+
 
 ;; borrowed from ido.el and modified to work better when vertical
 (defun sd/ido-completions (name)
@@ -136,16 +134,6 @@
 	      (nth 1 ido-decorations)))))))
 
 (defun turn-on-ido-vertical ()
-  (setq sd/old-ido-enable-flex-matching ido-enable-flex-matching)
-  (setq ido-enable-flex-matching t)
-
-  (setq sd/old-ido-auto-merge-delay-time ido-auto-merge-delay-time)
-  (setq ido-auto-merge-delay-time 99999)
-
-  (when (boundp 'ido-ubiquitous-enable-compatibility)
-    (setq sd/old-ido-ubiquitous-enable-compatibility ido-ubiquitous-enable-compatibility)
-    (setq ido-ubiquitous-enable-compatibility nil))
-
   (setq sd/old-ido-decorations ido-decorations)
   (setq sd/old-ido-completions (symbol-function 'ido-completions))
 
@@ -156,10 +144,6 @@
   (add-hook 'ido-setup-hook 'sd/ido-define-keys))
 
 (defun turn-off-ido-vertical ()
-  (setq ido-enable-flex-matching sd/old-ido-enable-flex-matching)
-  (setq ido-auto-merge-delay-time sd/old-ido-auto-merge-delay-time)
-  (when (boundp 'ido-ubiquitous-enable-compatibility)
-    (setq ido-ubiquitous-enable-compatibility sd/old-ido-ubiquitous-enable-compatibility))
   (setq ido-decorations sd/old-ido-decorations)
   (fset 'ido-completions sd/old-ido-completions)
 


### PR DESCRIPTION
As discussed per mail, I am opening an issue.

Currently IDO Vertical Mode changes a number of settings of other
packages, overriding their reasonable defaults as well as any user
customization.

This PR removes all this code.  Imho it's not at all necessary for this
package, and rather seems to be a left-over from the extraction of this
code out of a personal configuration (a conjecture supported by the
rather strange namespacing of these variables and functions).

Changing `ido-ubiquitous-enable-compatibility` to nil is even pretty
harmful, as it breaks a considerable share of `completing-read` usage,
that relies on this old style usage pattern.

For instance,
1. Enable `ido-vertical-mode` and `ido-ubiquitous-mode`
2. Verify that `ido-ubiquitous-enable-compatibility` is nil
3. Open an empty Emacs Lisp file
4. `M-x auto-insert`
5. Enter any text
6. Observe how you can't get out of the keyword prompt anymore

And really, a package should meddle with other packages' defaults.
