### PR TITLE
Add ido-vertical-keep-static

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and [`smex`](https://github.com/nonsequitur/smex).
 
 ## Install via [MELPA Stable](http://stable.melpa.org/#/) or [marmalade](http://marmalade-repo.org)
 
-`M-x` `package-install` `ido-vertical-mode`
+`M-x package-install ido-vertical-mode`
 
 If you use MELPA instead of MELPA Stable, there's no guarantee that
 you'll get something that works; I've accidentally broken master
@@ -21,10 +21,12 @@ before and will unfortunately probably do it again :(
 
 ## Turn it on
 
-    (require 'ido-vertical-mode)
-    (ido-mode 1)
-    (ido-vertical-mode 1)
-    (setq ido-vertical-define-keys 'C-n-and-C-p-only)
+``` elisp
+(require 'ido-vertical-mode)
+(ido-mode 1)
+(ido-vertical-mode 1)
+(setq ido-vertical-define-keys 'C-n-and-C-p-only)
+```
 
 Or you can use `M-x ido-vertical-mode` to toggle it.
 
@@ -41,7 +43,7 @@ for more information.
 
 Show the count of candidates:
 
-```elisp
+``` elisp
 (setq ido-vertical-show-count t)
 ```
 
@@ -49,7 +51,7 @@ Show the count of candidates:
 
 Make it look like @abo-abo's [blog post](http://oremacs.com/2015/02/09/ido-vertical/):
 
-```elisp
+``` elisp
 (setq ido-use-faces t)
 (set-face-attribute 'ido-vertical-first-match-face nil
                     :background "#e5b7c0")
@@ -63,7 +65,7 @@ Make it look like @abo-abo's [blog post](http://oremacs.com/2015/02/09/ido-verti
 
 Make it look like the screenshot above:
 
-```elisp
+```  elisp
 (setq ido-use-faces t)
 (set-face-attribute 'ido-vertical-first-match-face nil
                     :background nil
@@ -78,7 +80,7 @@ Make it look like the screenshot above:
 
 Reset the faces to their defaults:
 
-```elisp
+``` elisp
 (set-face-attribute 'ido-vertical-first-match-face nil
                     :background nil
                     :foreground nil)
@@ -101,23 +103,31 @@ Since the prospects are listed vertically, it might make sense to use
 standard `C-s` and `C-r`.  To accomplish this, set
 `ido-vertical-define-keys` like this:
 
-    (setq ido-vertical-define-keys 'C-n-and-C-p-only)
+``` elisp
+(setq ido-vertical-define-keys 'C-n-and-C-p-only)
+```
 
 The standard binding for `C-p` - `ido-toggle-prefix` - will now be
 available on `C-c C-t`, which was previously unbound in `ido-mode`'s
 key map. Of course, you can also put `ido-toggle-prefix` somewhere
 else on your own:
 
-    ;; manually mimic the 0.1.5 behavior of ido-vertical-mode
-    (define-key ido-completion-map (kbd "M-p") 'ido-toggle-prefix)
+``` elisp
+;; manually mimic the 0.1.5 behavior of ido-vertical-mode
+(define-key ido-completion-map (kbd "M-p") 'ido-toggle-prefix)
+```
 
 You also have the option to rebind some or all of the arrow keys with
 like this:
 
-    (setq ido-vertical-define-keys 'C-n-C-p-up-and-down)
+``` elisp
+(setq ido-vertical-define-keys 'C-n-C-p-up-and-down)
+```
 
 to use up and down to navigate the options, or:
 
-    (setq ido-vertical-define-keys 'C-n-C-p-up-down-left-right)
+``` elisp
+(setq ido-vertical-define-keys 'C-n-C-p-up-down-left-right)
+```
 
 to use left and right to move through the history/directories.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ for more information.
 
 ## Customize
 
+#### Static / Fixed
+
+Keep the list as static as possible while moving to the next/previous elements:
+
+```elisp
+(setq ido-vertical-keep-static t)
+```
+
 #### Count
 
 Show the count of candidates:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Keep the list as static as possible while moving to the next/previous elements:
 (setq ido-vertical-keep-static t)
 ```
 
+![screenshot-static.gif](screenshot-static.gif)
+
 #### Count
 
 Show the count of candidates:

--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -311,6 +311,7 @@ This is based on:
 (define-minor-mode ido-vertical-mode
   "Makes ido-mode display vertically."
   :global t
+  :group ido-vertical-mode
   (if ido-vertical-mode
       (turn-on-ido-vertical)
     (turn-off-ido-vertical)))

--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -121,12 +121,13 @@ so we can restore it when turning `ido-vertical-mode' off")
   (let* ((completions ido-matches)
          (completions-length (length completions))
          (completions-empty (null completions))
+         (minibuffer-available-lines (1- (min ido-max-prospects (ido-vertical-minibuffer-max-height))))
          (additional-items-indicator (nth 3 ido-decorations)))
 
     ;; Keep the height of the suggestions list constant by padding
     ;; when completions-length is too small. Also, if completions-length is too short, we
     ;; should not indicate that there are additional prospects.
-    (when (< completions-length (1+ ido-max-prospects))
+    (when (< completions-length minibuffer-available-lines)
       (setq additional-items-indicator "\n")
       (setq completions (append completions (make-list (- (1+ ido-max-prospects) completions-length) ""))))
 
@@ -137,7 +138,7 @@ so we can restore it when turning `ido-vertical-mode' off")
       (when (eq completions ido-matches)
         (setq completions (copy-sequence ido-matches)))
 
-      (dotimes (i ido-max-prospects)
+      (dotimes (i minibuffer-available-lines)
         (setf (nth i completions) (substring (if (listp (nth i completions))
                                                  (car (nth i completions))
                                                (nth i completions))
@@ -172,7 +173,7 @@ so we can restore it when turning `ido-vertical-mode' off")
                            (nth 12 ido-decorations))
                    (when (not ido-use-faces) (nth 7 ido-decorations)))) ;; [Matched]
           (t                            ;multiple matches
-           (let* ((items (if (> ido-max-prospects 0) (1+ ido-max-prospects) 999))
+           (let* ((items minibuffer-available-lines)
                   (items-count items)
                   (alternatives
                    (apply
@@ -224,6 +225,10 @@ so we can restore it when turning `ido-vertical-mode' off")
   (if (fboundp 'add-face-text-property)
       (add-face-text-property start stop face nil str)
     (put-text-property start stop 'face face str)))
+
+(defun ido-vertical-minibuffer-max-height ()
+  "Compute the maximum theoric size of the minibuffer."
+  (floor (* max-mini-window-height (/ (frame-pixel-height) (frame-char-height)))))
 
 (defun ido-vertical-disable-line-truncation ()
   "Prevent the newlines in the minibuffer from being truncated"

--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -127,10 +127,9 @@ so we can restore it when turning `ido-vertical-mode' off")
     ;; Keep the height of the suggestions list constant by padding
     ;; when lencomps is too small. Also, if lencomps is too short, we
     ;; should not indicate that there are additional prospects.
-    (if (< lencomps (1+ ido-max-prospects))
-        (progn
-          (setq additional-items-indicator "\n")
-          (setq comps (append comps (make-list (- (1+ ido-max-prospects) lencomps) "")))))
+    (when (< lencomps (1+ ido-max-prospects))
+      (setq additional-items-indicator "\n")
+      (setq comps (append comps (make-list (- (1+ ido-max-prospects) lencomps) ""))))
 
     (when ido-use-faces
       ;; Make a copy of [ido-matches], otherwise the selected string
@@ -151,8 +150,8 @@ so we can restore it when turning `ido-vertical-mode' off")
                                     'ido-vertical-match-face
                                     nil (nth i comps))))))
 
-    (if (and ind ido-use-faces)
-        (put-text-property 0 1 'face 'ido-indicator ind))
+    (when (and ind ido-use-faces)
+      (put-text-property 0 1 'face 'ido-indicator ind))
 
     (when ido-vertical-show-count
       (setcar ido-vertical-decorations (format " [%d]\n-> " lencomps))
@@ -162,30 +161,30 @@ so we can restore it when turning `ido-vertical-mode' off")
       (setcar ido-vertical-decorations "\n-> ")
       (setq ido-vertical-count-active nil))
 
-    (if (and ido-use-faces comps)
-        (let* ((fn (ido-name (car comps)))
-               (ln (length fn)))
-          (setq first (format "%s" fn))
-          (if (fboundp 'add-face-text-property)
-              (add-face-text-property 0 (length first)
-                                      (cond ((> lencomps 1)
-                                             'ido-vertical-first-match-face)
+    (when (and ido-use-faces comps)
+      (let* ((fn (ido-name (car comps)))
+             (ln (length fn)))
+        (setq first (format "%s" fn))
+        (if (fboundp 'add-face-text-property)
+            (add-face-text-property 0 (length first)
+                                    (cond ((> lencomps 1)
+                                           'ido-vertical-first-match-face)
 
-                                            (ido-incomplete-regexp
-                                             'ido-incomplete-regexp)
+                                          (ido-incomplete-regexp
+                                           'ido-incomplete-regexp)
 
-                                            (t
-                                             'ido-vertical-only-match-face))
-                                      nil first)
-            (put-text-property 0 ln 'face
-                               (if (= lencomps 1)
-                                   (if ido-incomplete-regexp
-                                       'ido-incomplete-regexp
-                                     'ido-vertical-only-match-face)
-                                 'ido-vertical-first-match-face)
-                               first))
-          (if ind (setq first (concat first ind)))
-          (setq comps (cons first (cdr comps)))))
+                                          (t
+                                           'ido-vertical-only-match-face))
+                                    nil first)
+          (put-text-property 0 ln 'face
+                             (if (= lencomps 1)
+                                 (if ido-incomplete-regexp
+                                     'ido-incomplete-regexp
+                                   'ido-vertical-only-match-face)
+                               'ido-vertical-first-match-face)
+                             first))
+        (when ind (setq first (concat first ind)))
+        (setq comps (cons first (cdr comps)))))
 
     ;; Previously we'd check null comps to see if the list was
     ;; empty. We pad the list with empty items to keep the list at a
@@ -208,7 +207,7 @@ so we can restore it when turning `ido-vertical-mode' off")
            (concat (concat (nth 11 ido-decorations) ;; [ ... ]
                            (ido-name (car comps))
                            (nth 12 ido-decorations))
-                   (if (not ido-use-faces) (nth 7 ido-decorations)))) ;; [Matched]
+                   (when (not ido-use-faces) (nth 7 ido-decorations)))) ;; [Matched]
           (t                            ;multiple matches
            (let* ((items (if (> ido-max-prospects 0) (1+ ido-max-prospects) 999))
                   (alternatives
@@ -226,20 +225,20 @@ so we can restore it when turning `ido-vertical-mode' off")
                               (t
                                (list (nth 2 ido-decorations) ; " | "
                                      (let ((str (substring com 0)))
-                                       (if (and ido-use-faces
-                                                (not (string= str first))
-                                                (ido-final-slash str))
-                                           (put-text-property 0 (length str) 'face 'ido-subdir str))
+                                       (when (and ido-use-faces
+                                                  (not (string= str first))
+                                                  (ido-final-slash str))
+                                         (put-text-property 0 (length str) 'face 'ido-subdir str))
                                        str)))))
                            comps))))))
 
              (concat
               ;; put in common completion item -- what you get by pressing tab
-              (if (and (stringp ido-common-match-string)
-                       (> (length ido-common-match-string) (length name)))
-                  (concat (nth 4 ido-decorations) ;; [ ... ]
-                          (substring ido-common-match-string (length name))
-                          (nth 5 ido-decorations)))
+              (when (and (stringp ido-common-match-string)
+                         (> (length ido-common-match-string) (length name)))
+                (concat (nth 4 ido-decorations) ;; [ ... ]
+                        (substring ido-common-match-string (length name))
+                        (nth 5 ido-decorations)))
               ;; list all alternatives
               (nth 0 ido-decorations) ;; { ... }
               alternatives
@@ -250,11 +249,10 @@ so we can restore it when turning `ido-vertical-mode' off")
   (set (make-local-variable 'truncate-lines) nil))
 
 (defun turn-on-ido-vertical ()
-  (if (and (eq nil ido-vertical-old-decorations)
-           (eq nil ido-vertical-old-completions))
-      (progn
-        (setq ido-vertical-old-decorations ido-decorations)
-        (setq ido-vertical-old-completions (symbol-function 'ido-completions))))
+  (when (and (eq nil ido-vertical-old-decorations)
+             (eq nil ido-vertical-old-completions))
+    (setq ido-vertical-old-decorations ido-decorations)
+    (setq ido-vertical-old-completions (symbol-function 'ido-completions)))
 
   (setq ido-decorations ido-vertical-decorations)
   (fset 'ido-completions 'ido-vertical-completions)

--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -84,9 +84,6 @@ so we can restore it when turning `ido-vertical-mode' off")
   :type 'boolean
   :group 'ido-vertical-mode)
 
-(defvar ido-vertical-count-active nil
-  "Used internally to track whether we're already showing the count")
-
 (defcustom ido-vertical-define-keys nil
   "Defines which keys that `ido-vertical-mode' redefines."
   :type '(choice
@@ -153,14 +150,6 @@ so we can restore it when turning `ido-vertical-mode' off")
                                     'ido-vertical-match-face
                                     nil (nth i comps))))))
 
-    (when ido-vertical-show-count
-      (setcar ido-vertical-decorations (format " [%d]\n-> " lencomps))
-      (setq ido-vertical-count-active t))
-    (when (and (not ido-vertical-show-count)
-               ido-vertical-count-active)
-      (setcar ido-vertical-decorations "\n-> ")
-      (setq ido-vertical-count-active nil))
-
     ;; Previously we'd check null comps to see if the list was
     ;; empty. We pad the list with empty items to keep the list at a
     ;; constant height, so we have to check if the entire list is
@@ -224,7 +213,10 @@ so we can restore it when turning `ido-vertical-mode' off")
                         (substring ido-common-match-string (length name))
                         (nth 5 ido-decorations)))
               ;; list all alternatives
-              (nth (if (equal 0 ido-vertical-selected-offset) 0 2) ido-decorations)
+              (let ((decoration (nth (if (equal 0 ido-vertical-selected-offset) 0 2) ido-decorations)))
+                (when ido-vertical-show-count
+                  (setq decoration (format " [%d]%s" lencomps decoration)))
+                decoration)
               alternatives
               (nth 1 ido-decorations)))))))
 

--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -187,14 +187,14 @@ so we can restore it when turning `ido-vertical-mode' off")
                               ((< items 0) ())
                               ((= items 0) (list additional-items-indicator)) ; " | ..."
                               (t
-                               (list (nth (if (equal (- items-count items 1) ido-vertical-selected-offset) 0 2) ido-decorations)
+                               (list (nth (if (= (- items-count items 1) ido-vertical-selected-offset) 0 2) ido-decorations)
                                      (let ((str (substring completion 0)))
                                        (when ido-use-faces
                                          (ido-vertical-propertize-text 0
                                                                        (length str)
-                                                                       (cond ((equal completions-length 1)
+                                                                       (cond ((= completions-length 1)
                                                                               'ido-vertical-only-match-face)
-                                                                             ((equal (- items-count items 1) ido-vertical-selected-offset)
+                                                                             ((= (- items-count items 1) ido-vertical-selected-offset)
                                                                               'ido-vertical-first-match-face)
                                                                              (ido-incomplete-regexp
                                                                               'ido-incomplete-regexp)
@@ -212,7 +212,7 @@ so we can restore it when turning `ido-vertical-mode' off")
                         (substring ido-common-match-string (length name))
                         (nth 5 ido-decorations)))
               ;; list all alternatives
-              (let ((decoration (nth (if (equal 0 ido-vertical-selected-offset) 0 2) ido-decorations)))
+              (let ((decoration (nth (if (= 0 ido-vertical-selected-offset) 0 2) ido-decorations)))
                 (when ido-vertical-show-count
                   (setq decoration (format " [%d]%s" completions-length decoration)))
                 decoration)

--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -118,43 +118,42 @@ so we can restore it when turning `ido-vertical-mode' off")
   ;; Return the string that is displayed after the user's text.
   ;; Modified from `icomplete-completions'.
 
-  (let* ((comps ido-matches)
-         (lencomps (length comps))
-         (additional-items-indicator (nth 3 ido-decorations))
-         (comps-empty (null comps))
-         first)
+  (let* ((completions ido-matches)
+         (completions-length (length completions))
+         (completions-empty (null completions))
+         (additional-items-indicator (nth 3 ido-decorations)))
 
     ;; Keep the height of the suggestions list constant by padding
-    ;; when lencomps is too small. Also, if lencomps is too short, we
+    ;; when completions-length is too small. Also, if completions-length is too short, we
     ;; should not indicate that there are additional prospects.
-    (when (< lencomps (1+ ido-max-prospects))
+    (when (< completions-length (1+ ido-max-prospects))
       (setq additional-items-indicator "\n")
-      (setq comps (append comps (make-list (- (1+ ido-max-prospects) lencomps) ""))))
+      (setq completions (append completions (make-list (- (1+ ido-max-prospects) completions-length) ""))))
 
     (when ido-use-faces
       ;; Make a copy of [ido-matches], otherwise the selected string
       ;; could contain text properties which could lead to weird
       ;; artifacts, e.g. buffer-file-name having text properties.
-      (when (eq comps ido-matches)
-        (setq comps (copy-sequence ido-matches)))
+      (when (eq completions ido-matches)
+        (setq completions (copy-sequence ido-matches)))
 
       (dotimes (i ido-max-prospects)
-        (setf (nth i comps) (substring (if (listp (nth i comps))
-                                           (car (nth i comps))
-                                         (nth i comps))
-                                       0))
-        (when (string-match name (nth i comps))
+        (setf (nth i completions) (substring (if (listp (nth i completions))
+                                                 (car (nth i completions))
+                                               (nth i completions))
+                                             0))
+        (when (string-match name (nth i completions))
           (ignore-errors
             (add-face-text-property (match-beginning 0)
                                     (match-end 0)
                                     'ido-vertical-match-face
-                                    nil (nth i comps))))))
+                                    nil (nth i completions))))))
 
-    ;; Previously we'd check null comps to see if the list was
+    ;; Previously we'd check null completions to see if the list was
     ;; empty. We pad the list with empty items to keep the list at a
     ;; constant height, so we have to check if the entire list is
-    ;; empty, instead of (null comps)
-    (cond (comps-empty
+    ;; empty, instead of (null completions)
+    (cond (completions-empty
            (cond
             (ido-show-confirm-message
              (or (nth 10 ido-decorations) " [Confirm]"))
@@ -166,10 +165,10 @@ so we can restore it when turning `ido-vertical-mode' off")
              (nth 6 ido-decorations)) ;; [No match]
             (t "")))
           (ido-incomplete-regexp
-           (concat " " (car comps)))
-          ((null (cdr comps))                       ;one match
+           (concat " " (car completions)))
+          ((null (cdr completions))                       ;one match
            (concat (concat (nth 11 ido-decorations) ;; [ ... ]
-                           (ido-name (car comps))
+                           (ido-name (car completions))
                            (nth 12 ido-decorations))
                    (when (not ido-use-faces) (nth 7 ido-decorations)))) ;; [Matched]
           (t                            ;multiple matches
@@ -181,19 +180,19 @@ so we can restore it when turning `ido-vertical-mode' off")
                     (cdr (apply
                           #'nconc
                           (mapcar
-                           (lambda (com)
-                             (setq com (ido-name com))
+                           (lambda (completion)
+                             (setq completion (ido-name completion))
                              (setq items (1- items))
                              (cond
                               ((< items 0) ())
                               ((= items 0) (list additional-items-indicator)) ; " | ..."
                               (t
                                (list (nth (if (equal (- items-count items 1) ido-vertical-selected-offset) 0 2) ido-decorations)
-                                     (let ((str (substring com 0)))
+                                     (let ((str (substring completion 0)))
                                        (when ido-use-faces
                                          (ido-vertical-propertize-text 0
                                                                        (length str)
-                                                                       (cond ((equal lencomps 1)
+                                                                       (cond ((equal completions-length 1)
                                                                               'ido-vertical-only-match-face)
                                                                              ((equal (- items-count items 1) ido-vertical-selected-offset)
                                                                               'ido-vertical-first-match-face)
@@ -203,7 +202,7 @@ so we can restore it when turning `ido-vertical-mode' off")
                                                                               'ido-subdir))
                                                                        str))
                                        str)))))
-                           comps))))))
+                           completions))))))
 
              (concat
               ;; put in common completion item -- what you get by pressing tab
@@ -215,7 +214,7 @@ so we can restore it when turning `ido-vertical-mode' off")
               ;; list all alternatives
               (let ((decoration (nth (if (equal 0 ido-vertical-selected-offset) 0 2) ido-decorations)))
                 (when ido-vertical-show-count
-                  (setq decoration (format " [%d]%s" lencomps decoration)))
+                  (setq decoration (format " [%d]%s" completions-length decoration)))
                 decoration)
               alternatives
               (nth 1 ido-decorations)))))))

--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -168,10 +168,10 @@ so we can restore it when turning `ido-vertical-mode' off")
           (ido-incomplete-regexp
            (concat " " (car completions)))
           ((null (cdr completions))                       ;one match
-           (concat (concat (nth 11 ido-decorations) ;; [ ... ]
-                           (ido-name (car completions))
-                           (nth 12 ido-decorations))
-                   (when (not ido-use-faces) (nth 7 ido-decorations)))) ;; [Matched]
+           (concat (nth 11 ido-decorations) ;; [ ... ]
+                   (ido-name (car completions))
+                   (nth 12 ido-decorations)
+                   (nth 7 ido-decorations))) ;; [Matched]
           (t                            ;multiple matches
            (let* ((items minibuffer-available-lines)
                   (items-count items)


### PR DESCRIPTION
Hello,

Don't merge this yet, but eventually it'll fix #19.

Tell me what you think. I tried to find a better name than `ido-vertical-keep-static` but couldn't... if you have a better idea.

I still have a few bugs to iron out, namely that for smex when there is a lot of items and it displays `...` then it bugs and doesn't scroll the list properly. If you find other bugs, please share and we'll fix them before you merge :)

**TODO**:

- [x] fix when there's a lot of items (smex) and it displays `...`
- [x] fix the left/right keys (e.g next directory)
- [x] make it so the "selected" face is correctly applied when moving down (didn't notice because of `flx-ido`)