### PR TITLE
Add two features

### DIFF
--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -100,6 +100,12 @@ so we can restore it when turning `ido-vertical-mode' off")
   "Non nil means to pad the list of candidates to ensure the minibuffer area is always tall"
   :type 'boolean
   :group 'ido-vertical-mode)
+
+(defcustom ido-vertical-disable-if-short nil
+  "Non nil means that ido will go back to horizontal mode if the candidates all fit in the minibuffer area"
+  :type 'boolean
+  :group 'ido-vertical-mode)
+
 (defface ido-vertical-first-match-face
   '((t (:inherit ido-first-match)))
   "Face used by Ido Vertical for highlighting first match."
@@ -114,6 +120,21 @@ so we can restore it when turning `ido-vertical-mode' off")
   '((t (:inherit font-lock-variable-name-face :bold t :underline t)))
   "Face used by Ido Vertical for the matched part."
   :group 'ido-vertical-mode)
+
+(defun ido-vertical-or-horizontal-completions (name)
+  (if (and ido-vertical-disable-if-short
+           (<= (length ido-matches) ido-max-prospects))
+
+      (let ((short-result
+             (let ((ido-decorations ido-vertical-old-decorations))
+               (funcall ido-vertical-old-completions name))))
+        (if (>= (window-body-width (minibuffer-window))
+                (+ (minibuffer-prompt-width)
+                   (length short-result)))
+            short-result
+          (ido-vertical-completions name)))
+
+    (ido-vertical-completions name)))
 
 ;; borrowed from ido.el and modified to work better when vertical
 (defun ido-vertical-completions (name)
@@ -267,7 +288,7 @@ so we can restore it when turning `ido-vertical-mode' off")
         (setq ido-vertical-old-completions (symbol-function 'ido-completions))))
 
   (setq ido-decorations ido-vertical-decorations)
-  (fset 'ido-completions 'ido-vertical-completions)
+  (fset 'ido-completions 'ido-vertical-or-horizontal-completions)
 
   (add-hook 'ido-minibuffer-setup-hook 'ido-vertical-disable-line-truncation)
   (add-hook 'ido-setup-hook 'ido-vertical-define-keys))

--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -153,11 +153,11 @@ so we can restore it when turning `ido-vertical-mode' off")
     ;; Keep the height of the suggestions list constant by padding
     ;; when lencomps is too small. Also, if lencomps is too short, we
     ;; should not indicate that there are additional prospects.
-    (when (and ido-vertical-pad-list
-               (< lencomps (1+ ido-max-prospects)))
+    (when (< lencomps (1+ ido-max-prospects))
       (setq additional-items-indicator "\n")
-      (setq comps (append comps (make-list (- (1+ ido-max-prospects) lencomps) "")))
-      (setq ncomps (length comps)))
+      (when ido-vertical-pad-list
+        (setq comps (append comps (make-list (- (1+ ido-max-prospects) lencomps) "")))
+        (setq ncomps (length comps))))
 
     (if (not ido-incomplete-regexp)
         (when ido-use-faces


### PR DESCRIPTION
Hello,

I really like ido-vertical-mode, but I have hacked it to be slightly more to my liking: this patch adds two extra custom settings, one which lets the vertical presentation shrink the minibuffer (so if there are only 3 suggestions you don't get ido-max-prospects - 3 blank lines), and one which goes back to horizontal presentation if there are fewer than ido-max-prospects options and they would all fit in one minibuffer line.

I know that not everyone likes things that jump about on the screen, so I have made these customizations default to the standard ido-vertical-mode behaviour.

If you'd like these amendments here they are!

cheers,

tom