### PR TITLE
 Some more changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Reset the faces to their defaults:
 (setq ido-use-faces nil)
 ```
 
+If your regex has multiple groups, `ido-vertical-mode` will highlight
+them independently.
+
 #### Alternative Key Bindings
 
 Since the prospects are listed vertically, it might make sense to use
@@ -121,3 +124,16 @@ to use up and down to navigate the options, or:
     (setq ido-vertical-define-keys 'C-n-C-p-up-down-left-right)
 
 to use left and right to move through the history/directories.
+
+#### Shrinking to fit
+
+By default, ido-vertical-mode will display `ido-max-prospects` lines
+even if there are fewer suggestions. You can toggle this by setting
+or clearing the customisation `ido-vertical-pad-list`. You may also
+need to set `resize-mini-windows` to `t` to persuade emacs to let the
+minibuffer shrink.
+
+If you want to shrink the results even more, you can customize
+`ido-vertical-disable-if-short`; this will revert to normal ido if
+there are `ido-max-prospects` or fewer things to display, and the
+resulting suggestion string would fit in one line of the minibuffer.

--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -353,58 +353,19 @@ so we can restore it when turning `ido-vertical-mode' off")
                     (/ (+ ncandidates columns -1)
                        columns)))))))
 
-(defun ido-vertical--exit-minibuffer (o &rest args)
-  ;; make ido know that current match is selected
+(defun ido-vertical--set-first-match-adv (o &rest args)
   (dotimes (n ido-vertical--offset)
-    (ido-next-match)) ;; for some reason below doesn't work
-
-  ;; (when ido-matches
-  ;;   (let ((next (nth ido-vertical--offset ido-matches)))
-  ;;     (setq ido-cur-list (ido-chop ido-cur-list next))
-  ;;     (setq ido-rescan t)
-  ;;     (setq ido-rotate t)))
-
-  ;; carry on
+    (ido-next-match))
   (setf ido-vertical--offset 0)
   (apply o args))
 
-(advice-add 'ido-exit-minibuffer :around #'ido-vertical--exit-minibuffer)
+(defun ido-vertical--set-first-match-adv-temp (o &rest args)
+  (let ((ido-matches (nthcdr ido-vertical--offset ido-matches)))
+       (apply o args)))
 
-;; (defvar ido-vertical--just-activated nil)
-
-;; (defun ido-vertical--set-matches (o &rest args)
-;;   ;; keep position when possible?
-;;   (if ido-vertical--just-activated
-;;       (progn
-;;         (setf ido-vertical--just-activated nil)
-;;         (apply o args))
-
-;;     (let ((old-offset ido-vertical--offset)
-;;           old-item)
-
-;;       (ignore-errors
-;;         (setf old-item (nth old-offset ido-matches)))
-
-;;       (apply o args)
-
-;;       (ignore-errors
-;;         (setf ido-vertical--offset
-;;               (or (position old-item ido-matches)
-;;                   0))
-
-;;         )
-
-;;       (unless (< 0 ido-vertical--offset ido-vertical--visible-count)
-;;         (setf ido-vertical--offset 0))
-;;       )))
-
-
-(advice-remove 'ido-set-matches #'ido-vertical--set-matches)
-
-;; (add-hook 'ido-setup-hook
-;;           (lambda ()
-;;             (setf ido-vertical--just-activated t)))
-
+(advice-add 'ido-exit-minibuffer :around #'ido-vertical--set-first-match-adv)
+(advice-add 'ido-kill-buffer-at-head :around #'ido-vertical--set-first-match-adv-temp)
+(advice-add 'ido-delete-file-at-head :around #'ido-vertical--set-first-match-adv-temp)
 
 (defun ido-vertical-completions (name)
   "Produce text to go in the minibuffer from `ido-matches' and NAME"

--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -112,11 +112,6 @@ so we can restore it when turning `ido-vertical-mode' off")
   :type 'integer
   :group 'ido-vertical-mode)
 
-(defcustom ido-vertical-disable-if-short nil
-  "Non nil means that ido will go back to horizontal mode if the candidates all fit in the minibuffer area"
-  :type 'boolean
-  :group 'ido-vertical-mode)
-
 (defface ido-vertical-first-match-face
   '((t (:inherit ido-first-match)))
   "Face used by Ido Vertical for highlighting first match."
@@ -132,20 +127,20 @@ so we can restore it when turning `ido-vertical-mode' off")
   "Face used by Ido Vertical for the matched part."
   :group 'ido-vertical-mode)
 
-(defun ido-vertical-or-horizontal-completions (name)
-  (if (and ido-vertical-disable-if-short
-           (<= (length ido-matches) ido-max-prospects))
+;; (defun ido-vertical-or-horizontal-completions (name)
+;;   (if (and ido-vertical-disable-if-short
+;;            (<= (length ido-matches) ido-max-prospects))
 
-      (let ((short-result
-             (let ((ido-decorations ido-vertical-old-decorations))
-               (funcall ido-vertical-old-completions name))))
-        (if (>= (window-body-width (minibuffer-window))
-                (+ (minibuffer-prompt-width)
-                   (length short-result)))
-            short-result
-          (ido-vertical-completions name)))
+;;       (let ((short-result
+;;              (let ((ido-decorations ido-vertical-old-decorations))
+;;                (funcall ido-vertical-old-completions name))))
+;;         (if (>= (window-body-width (minibuffer-window))
+;;                 (+ (minibuffer-prompt-width)
+;;                    (length short-result)))
+;;             short-result
+;;           (ido-vertical-completions name)))
 
-    (ido-vertical-completions name)))
+;;     (ido-vertical-completions name)))
 
 (defvar ido-vertical--visible-count 0
   "how many items got drawn - modified by using ido-vertical--pack-columns")
@@ -544,7 +539,7 @@ so we can restore it when turning `ido-vertical-mode' off")
         (setq ido-vertical-old-completions (symbol-function 'ido-completions))))
 
   (setq ido-decorations ido-vertical-decorations)
-  (fset 'ido-completions 'ido-vertical-or-horizontal-completions)
+  (fset 'ido-completions 'ido-vertical-completions)
 
   (add-hook 'ido-minibuffer-setup-hook 'ido-vertical-disable-line-truncation)
   (add-hook 'ido-setup-hook 'ido-vertical-define-keys)

--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -355,9 +355,8 @@ so we can restore it when turning `ido-vertical-mode' off")
 
 (defun ido-vertical--exit-minibuffer (o &rest args)
   ;; make ido know that current match is selected
-  (message (format  "exit minibuffer - fiddle offset %d" ido-vertical--offset))
   (dotimes (n ido-vertical--offset)
-    (ido-next-match))
+    (ido-next-match)) ;; for some reason below doesn't work
 
   ;; (when ido-matches
   ;;   (let ((next (nth ido-vertical--offset ido-matches)))
@@ -370,7 +369,42 @@ so we can restore it when turning `ido-vertical-mode' off")
   (apply o args))
 
 (advice-add 'ido-exit-minibuffer :around #'ido-vertical--exit-minibuffer)
-(advice-remove 'ido-exit-minibuffer #'ido-vertical--exit-minibuffer)
+
+;; (defvar ido-vertical--just-activated nil)
+
+;; (defun ido-vertical--set-matches (o &rest args)
+;;   ;; keep position when possible?
+;;   (if ido-vertical--just-activated
+;;       (progn
+;;         (setf ido-vertical--just-activated nil)
+;;         (apply o args))
+
+;;     (let ((old-offset ido-vertical--offset)
+;;           old-item)
+
+;;       (ignore-errors
+;;         (setf old-item (nth old-offset ido-matches)))
+
+;;       (apply o args)
+
+;;       (ignore-errors
+;;         (setf ido-vertical--offset
+;;               (or (position old-item ido-matches)
+;;                   0))
+
+;;         )
+
+;;       (unless (< 0 ido-vertical--offset ido-vertical--visible-count)
+;;         (setf ido-vertical--offset 0))
+;;       )))
+
+
+(advice-remove 'ido-set-matches #'ido-vertical--set-matches)
+
+;; (add-hook 'ido-setup-hook
+;;           (lambda ()
+;;             (setf ido-vertical--just-activated t)))
+
 
 (defun ido-vertical-completions (name)
   "Produce text to go in the minibuffer from `ido-matches' and NAME"
@@ -495,6 +529,7 @@ so we can restore it when turning `ido-vertical-mode' off")
                     ido-vertical-columns
                     ))
                   )
+
 
 
              (if (and (stringp ido-common-match-string)

--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -152,7 +152,8 @@ result will never contain more than that many elements."
 (defun ido-vertical--string-with-face (s face)
   "A convenience for taking a string, removing any faces, and then adding a face."
   (let ((s (substring-no-properties s 0)))
-    (add-face-text-property 0 (length s) face nil s)
+    (when ido-use-faces
+        (add-face-text-property 0 (length s) face nil s))
     s))
 
 (defun ido-vertical-completions (name)

--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -460,7 +460,7 @@ so we can restore it when turning `ido-vertical-mode' off")
                (add-face-text-property 0 1 'ido-indicator nil ind))
            (let* ((decoration-regexp (if ido-enable-regexp ido-text (regexp-quote name)))
                   (available-width (- (window-body-width (minibuffer-window)) 10))
-                  (column-separator "  |  ")
+                  (column-separator "  ")
                   (grid
 
                    (ido-vertical--pack-columns

--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -178,7 +178,7 @@ result will never contain more than that many elements."
          (deco-no-match-message (nth 6 ido-decorations))
          (deco-exact-match-message (nth 7 ido-decorations))
          (deco-not-readable-message (nth 8 ido-decorations))
-         (deco-too-big-messsage  (nth 9 ido-decorations) )
+         (deco-too-big-message  (nth 9 ido-decorations) )
          (deco-confirm-message (nth 10 ido-decorations))
          (deco-lb-match (nth 11 ido-decorations))
          (deco-rb-match (nth 12 ido-decorations))

--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -151,7 +151,7 @@ result will never contain more than that many elements."
 
 (defun ido-vertical--string-with-face (s face)
   "A convenience for taking a string, removing any faces, and then adding a face."
-  (let ((s (substring s 0)))
+  (let ((s (substring-no-properties s 0)))
     (add-face-text-property 0 (length s) face nil s)
     s))
 
@@ -237,7 +237,7 @@ result will never contain more than that many elements."
                  (setq previous-separator deco-between-prospect)
 
                  ;; remove existing text properties, and then add more on.
-                 (let ((prospect-name (substring (ido-name prospect) 0)))
+                 (let ((prospect-name (substring-no-properties (ido-name prospect) 0)))
                    ;; join the merged indicator on
                    (when (and ind first-prospect)
                      (setq prospect-name (concat prospect-name ind)))

--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -369,21 +369,19 @@ so we can restore it when turning `ido-vertical-mode' off")
       (or
        (catch 'break
          (dotimes (rows ido-vertical-rows)
-           (let* ((rc (1+ rows))
+           (let* ((rc (- ido-vertical-rows rows))
                   (rowlengths (make-list rc 0))
                   (rowlengths1 rowlengths))
              (dolist (w candidate-widths)
                (if (zerop (car rowlengths1))
                    (setf (car rowlengths1) w)
                  (incf (car rowlengths1) (+ w separator-width)))
-               (if (< (car rowlengths1) available-width)
-                   (throw 'break rc))
+               (if (>= (car rowlengths1) available-width)
+                   (throw 'break (1+ rc)))
 
                (setf rowlengths1 (or (cdr rowlengths1) rowlengths)) ;; rotate
-               )
-             )
-           ))
-       ido-vertical-rows))
+               ))))
+       1))
     ))
 
 (defun ido-vertical--set-first-match-adv (o &rest args)

--- a/test/ido-vertical-mode-test.el
+++ b/test/ido-vertical-mode-test.el
@@ -133,5 +133,7 @@
 ;;
 (ert-deftest ivm-should-allow-regexp ()
   (ido-vertical-mode 1)
-  (let ((query (ido-vertical-completions "scratch")))
-    (should (string= "\n-> *Messages*\n" (substring-no-properties query 0 15)))))
+  (let* ((ido-vertical-show-count nil)
+        (ido-matches '("*scratch*" "Another thing"))
+        (query (ido-vertical-completions "scratch")))
+    (should (string= "\n-> *scratch*\n" (substring-no-properties query 0 14)))))

--- a/test/ido-vertical-mode-test.el
+++ b/test/ido-vertical-mode-test.el
@@ -76,7 +76,8 @@
          (ido-query (ido-vertical-completions "ido"))
          (first-comp-pos (string-match "ido" ido-query))
          (ido-query-first-comp-face (get-text-property first-comp-pos 'face ido-query))
-         (debug nil))
+         (debug nil)
+         )
     (when debug (prin1 ido-query))
     (should (eq nil ido-query-first-comp-face))))
 
@@ -113,9 +114,9 @@
     (setq query (ido-vertical-completions ""))
     (should (string= " [5]\n" (substring query 0 5)))
     ;; Count should update when filtering completions
-    (setq ido-matches '("1"))
+    (setq ido-matches '("1" "2"))
     (setq query (ido-vertical-completions "1"))
-    (should (string= " [1]" (substring query 0 4)))))
+    (should (string= " [2]" (substring query 0 4)))))
 
 (ert-deftest ivm-should-turn-off-count ()
   (let* ((ido-matches '("1"))

--- a/test/ido-vertical-mode-test.el
+++ b/test/ido-vertical-mode-test.el
@@ -9,6 +9,24 @@
 ;;; otherwise throw void error
 (execute-kbd-macro [24 98 return] 1)
 
+(ert-deftest ivm-should-pad-when-padding ()
+  (let* ((ido-matches '("a" "b"))
+         (ido-max-prospects 4)
+         (ido-vertical-pad-list t)
+         (prospect-string (ido-vertical-completions "")))
+
+    (should (= (length (split-string prospect-string "\n"))
+               6))))
+
+(ert-deftest ivm-should-not-pad-when-not-padding ()
+  (let* ((ido-matches '("a" "b"))
+         (ido-max-prospects 4)
+         (ido-vertical-pad-list nil)
+         (prospect-string (ido-vertical-completions "")))
+
+    (should (= (length (split-string prospect-string "\n"))
+               3))))
+
 (ert-deftest ivm-should-install-decorations ()
   (ido-vertical-mode 1)
   (let ((prospects (ido-completions "")))


### PR DESCRIPTION
Hello,

I have done a little bit more work on this - you may not be so keen on these changes as one of them changes the behaviour of ido-vertical-mode. You can see this in the change to the tests; the difference is that it no longer displays the count when there is exactly one result. However, I have added tests for some of the new things, updated the readme, and rewritten the main function to make it faster (it now takes subsecond times to display things like `C-h f` whereas it was taking a couple of seconds on my machine, because it was adding text properties to every candidate rather than just the list to be displayed).

It also highlights regex match groups separately if there are any.

Cheers
tom