### PR TITLE
Fix `ido-vertical-mode` variable group

### DIFF
--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -342,6 +342,7 @@ This is based on:
 (define-minor-mode ido-vertical-mode
   "Makes ido-mode display vertically."
   :global t
+  :group 'ido-vertical-mode
   (if ido-vertical-mode
       (turn-on-ido-vertical)
     (turn-off-ido-vertical)))


### PR DESCRIPTION
Very small fix to allow the minor mode toggle to show up under the correct group. :-)

```
Add the `ido-vertical-mode' variable to the `ido-vertical-mode' group.

Previously it was assigned to the default `ido-vertical' group, which does
not have a definition and did not show up under the `ido-vertical-mode'
group customize menu.
```