### PR TITLE
Turn O(n^2) loop to O(n)

### DIFF
--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -169,23 +169,22 @@ so we can restore it when turning `ido-vertical-mode' off")
           ;; Make a copy of [ido-matches], otherwise the selected string
           ;; could contain text properties which could lead to weird
           ;; artifacts, e.g. buffer-file-name having text properties.
-          (when (eq comps ido-matches)
-            (setq comps (copy-sequence ido-matches)))
-
-          (dotimes (i ncomps)
-            (let ((comps-i (nth i comps)))
-              (setf comps-i
-                    (setf (nth i comps) (substring (if (listp comps-i)
-                                                       (car comps-i)
-                                                     comps-i)
-                                                   0)))
-
-              (when (string-match (if ido-enable-regexp name (regexp-quote name)) comps-i)
-                (ignore-errors
-                  (add-face-text-property (match-beginning 0)
-                                          (match-end 0)
-                                          'ido-vertical-match-face
-                                          nil comps-i)))))))
+          (setq comps (cl-loop for comps-i being the elements of (if (eq comps ido-matches)
+                                                                     ido-matches
+                                                                   comps)
+                               do
+                               (setf comps-i (substring-no-properties
+                                              (if (listp comps-i)
+                                                  (car comps-i)
+                                                comps-i)
+                                              0))
+                               (when (string-match (if ido-enable-regexp name (regexp-quote name)) comps-i)
+                                 (ignore-errors
+                                   (add-face-text-property (match-beginning 0)
+                                                           (match-end 0)
+                                                           'ido-vertical-match-face
+                                                           nil comps-i)))
+                               collect comps-i))))
 
     (if (and ind ido-use-faces)
         (put-text-property 0 1 'face 'ido-indicator ind))


### PR DESCRIPTION
Currently inside `ido-vertical-completions`, the loop is using `nth` twice to
modify the list of completions, this results in O(n^2) time and slows down
showing the list of completions tremendously. This PR turns that loop to O(n) time.

Benchmark results with `(flx-ido-mode)`, `C-u 100 M-x benchmark RET (ido-vertical-completions "pdpid")` 

Before:
`Elapsed time: 5.769146s (0.345513s in 3 GCs)`

After:
`Elapsed time: 1.223311s (0.226972s in 2 GCs)`