### PR TITLE
Require cl-lib

### DIFF
--- a/ido-vertical-mode.el
+++ b/ido-vertical-mode.el
@@ -28,6 +28,7 @@
 ;;; Code:
 
 (require 'ido)
+(require 'cl-lib)
 
 ;;; The following three variables and their comments are lifted
 ;;; directly from `ido.el'; they are defined here to avoid compile-log


### PR DESCRIPTION
This fixes the compiler warnings and free variable error when used in combination with ido-completing-read+ and amx