### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,45 @@
 language: emacs-lisp
+matrix:
+  include:
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-24.4-travis
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-24.5-travis
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-25.1-travis
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-25.2-travis
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-25.3-travis
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-26.1-travis-linux-xenial
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-26.2-travis-linux-xenial
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-26.3-travis-linux-xenial
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-27.1-travis-linux-xenial
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-git-snapshot-travis-linux-xenial
 before_install:
-  - curl -fsSkL https://gist.github.com/rejeep/7736123/raw > travis.sh && source ./travis.sh
-  - export PATH="/home/travis/.cask/bin:$PATH"
   - export PATH="/home/travis/.evm/bin:$PATH"
-  - evm install $EVM_EMACS --use
+  - export PATH="/home/travis/.cask/bin:$PATH"
+  - git clone https://github.com/rejeep/evm.git /home/travis/.evm
+  - evm config path /tmp
+  - evm install emacs-24.3-travis --use
+  - evm install $EVM_EMACS --use --skip
+  - curl -fsSkL https://raw.githubusercontent.com/cask/cask/master/go | python
   - cask
-env:
-  - EVM_EMACS=emacs-24.4-bin
 script:
   - emacs --version
   - cask exec ert-runner

--- a/Cask
+++ b/Cask
@@ -1,5 +1,4 @@
 (source melpa)
-(source marmalade)
 
 (package-file "ido-vertical-mode.el")
 


### PR DESCRIPTION
Make PRs build on Travis again. This is just a temp fix as evm does't have emacs binaries built for more recent Ubuntu releases, the longer term fix is probably be moving to Github Actions.